### PR TITLE
Keep go in filetype

### DIFF
--- a/ftdetect/ginkgo.vim
+++ b/ftdetect/ginkgo.vim
@@ -1,2 +1,2 @@
 " Go (Ginkgo)
-autocmd BufNewFile,BufReadPost *_test.go set filetype=ginkgo
+autocmd BufNewFile,BufReadPost *_test.go set filetype=ginkgo.go


### PR DESCRIPTION
Any interest in keeping go in the filetype? This lets things like other snippets I have work even in the test files.
